### PR TITLE
the "Better Filters" update

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,8 @@
 {
-  "extends": ["next", "prettier"]
+  "extends": [
+    "next",
+    "eslint:recommended",
+    "plugin:react/recommended",
+    "plugin:react-hooks/recommended"
+  ]
 }

--- a/app/admin/login/page.tsx
+++ b/app/admin/login/page.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { signInWithGithub, signOut } from '@/utils/supabase/auth';
 
 export default async function Page() {

--- a/app/browse/[collection]/page.tsx
+++ b/app/browse/[collection]/page.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import AlbumGrid from '@/components/AlbumGrid';
 import { createSupabaseClient } from '@/utils/supabase/createSupabaseClient';
 import { SortType, sortLegacyEntries } from '@/data/filters';

--- a/app/browse/[collection]/page.tsx
+++ b/app/browse/[collection]/page.tsx
@@ -4,7 +4,7 @@ import { SortType, sortLegacyEntries } from '@/data/filters';
 import { getFullList } from '@/utils/supabase/queries';
 import { FullAlbumDetails } from '@/data/types';
 
-export default async function Page({ params }: { params: { collection: SortType } }) {
+export default async function Page({ params }: { params: { collection: SortType['slug'] } }) {
   const sb = createSupabaseClient()
   const data = await getFullList(sb);
   const sortedAlbums = sortLegacyEntries(data, params.collection)

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,20 +1,11 @@
-import type { GetServerSideProps, Metadata } from 'next';
+import React from 'react';
+import type { Metadata } from 'next';
 import { Inter } from "next/font/google";
 import "./globals.css";
-import Link from 'next/link';
-import { SORTED_PAGES } from '@/data/filters';
 import Navigation from '@/components/Navigation';
 import { stringToColor } from '@/utils/color/stringToColor';
 
 const inter = Inter({ subsets: ["latin"] });
-
-const getServerSideProps: GetServerSideProps = async (context) => {
-  return {
-    props: {
-      currentPath: context.resolvedUrl
-    }
-  };
-};
 
 export const metadata: Metadata = {
   title: "some chick's vinyl collection",

--- a/components/AlbumCover.tsx
+++ b/components/AlbumCover.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import Image from 'next/image';
 import Pill from '@/components/atom/Pill';
 import { FullAlbumDetails } from '@/data/types';

--- a/components/AlbumGrid.tsx
+++ b/components/AlbumGrid.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import AlbumCover from '@/components/AlbumCover';
 import { FullAlbumDetails } from '@/data/types';
 

--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -15,10 +15,12 @@ function Navigation() {
   return (
     <ul className={"mt-6 ml-2 lg:ml-6"}>
       {SORTED_PAGES.map((pn, idx) => (
-        <Link key={idx} href={`/browse/${pn.slug}`}>
-          <li style={filter === pn.slug ? style : {}} className={'leading-8 text-3xl '}>{pn.label}</li>
-        </Link>
-      ))}
+        <li key={idx} style={filter === pn.slug ? style : {}} className={'leading-8 text-3xl '}>
+          <Link href={`/browse/${pn.slug}`}>
+            {pn.label}
+          </Link>
+        </li>
+        ))}
     </ul>
   );
 }

--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -15,8 +15,8 @@ function Navigation() {
   return (
     <ul className={"mt-6 ml-2 lg:ml-6"}>
       {SORTED_PAGES.map((pn, idx) => (
-        <Link key={idx} href={`/browse/${pn}`}>
-          <li style={filter === pn ? style : {}} className={'leading-8 text-3xl '}>{pn}</li>
+        <Link key={idx} href={`/browse/${pn.slug}`}>
+          <li style={filter === pn.slug ? style : {}} className={'leading-8 text-3xl '}>{pn.label}</li>
         </Link>
       ))}
     </ul>

--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -21,6 +21,6 @@ function Navigation() {
       ))}
     </ul>
   );
-};
+}
 
 export default Navigation;

--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -1,6 +1,6 @@
 "use client"
-import Link from 'next/link';
 import React from 'react';
+import Link from 'next/link';
 import { SORTED_PAGES } from '@/data/filters';
 import { usePathname } from 'next/navigation';
 import { stringToColor } from '@/utils/color/stringToColor';

--- a/components/atom/Pill.tsx
+++ b/components/atom/Pill.tsx
@@ -2,8 +2,8 @@ import { stringToColor } from '@/utils/color/stringToColor';
 import { ensureContrast } from '@/utils/color/ensureContrast';
 
 const Pill = ({ text, className }: { text: string, className?: string }) => {
-  let pillBg = stringToColor(text, "last", 60, 0.8);
-  let pillAccent = stringToColor(text, "last", 70);
+  let pillBg = stringToColor(text, "first", 60, 0.8);
+  let pillAccent = stringToColor(text, "first", 70);
   [pillBg, pillAccent] = ensureContrast(pillBg, pillAccent);
   const dynamicStyles = {
     backgroundColor: pillBg,

--- a/components/atom/Pill.tsx
+++ b/components/atom/Pill.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { stringToColor } from '@/utils/color/stringToColor';
 import { ensureContrast } from '@/utils/color/ensureContrast';
 

--- a/data/filters.ts
+++ b/data/filters.ts
@@ -4,7 +4,7 @@ import { FullAlbumDetails } from '@/data/types';
 export const SORTED_PAGES = ["newest", "artist(a-z)", "preorders"] as const
 export type SortType = typeof SORTED_PAGES[number]
 
-const isAcquired = (arg: FullAlbumDetails) => arg.acquired_date
+const isAcquired = (arg: FullAlbumDetails) => arg.acquired_date && new Date(arg.acquired_date).getTime() <= Date.now()
 const isPreorder = (arg: FullAlbumDetails) => arg.preordered
 const sortByTime = (aDate: Date, bDate: Date) => bDate.getTime() - aDate.getTime()
 
@@ -19,7 +19,7 @@ function sortArtists(args: FullAlbumDetails[]) {
 }
 
 function filterPreorders(args: FullAlbumDetails[]) {
-    return args.filter((arg) => isPreorder(arg) && !isAcquired(arg))
+    return args.filter((arg) => isPreorder(arg) && !isAcquired(arg)).sort((a, b) => sortByTime(new Date(a.purchase_date), new Date(b.purchase_date)))
 }
 
 export function sortLegacyEntries(args: FullAlbumDetails[], sort: SortType) {

--- a/data/filters.ts
+++ b/data/filters.ts
@@ -19,7 +19,9 @@ function sortArtists(args: FullAlbumDetails[]) {
 }
 
 function filterPreorders(args: FullAlbumDetails[]) {
-    return args.filter((arg) => isPreorder(arg) && !isAcquired(arg)).sort((a, b) => sortByTime(new Date(a.purchase_date), new Date(b.purchase_date)))
+    return args
+      .filter((arg) => isPreorder(arg) && !isAcquired(arg))
+      .sort((a, b) => sortByTime(new Date(b.acquired_date), new Date(a.acquired_date)))
 }
 
 export function sortLegacyEntries(args: FullAlbumDetails[], sort: SortType) {

--- a/data/filters.ts
+++ b/data/filters.ts
@@ -1,7 +1,10 @@
 import { groupAndSortByProperty } from '@/utils/groupAndSortByProperty';
 import { FullAlbumDetails } from '@/data/types';
 
-export const SORTED_PAGES = ["newest", "artist(a-z)", "preorders"] as const
+export const SORTED_PAGES = [
+    {label: "newest", slug: "newest"},
+    {label: "artist(a-z)", slug: "artist-alphabetical"},
+    {label: "orders+preorders", slug: "orders-preorders"}] as const
 export type SortType = typeof SORTED_PAGES[number]
 
 const isAcquired = (arg: FullAlbumDetails) => arg.acquired_date && new Date(arg.acquired_date).getTime() <= Date.now()
@@ -15,22 +18,29 @@ function sortRecentlyAdded(args: FullAlbumDetails[]) {
 }
 
 function sortArtists(args: FullAlbumDetails[]) {
-    return groupAndSortByProperty<FullAlbumDetails>(args, "artist_name", "title").flat();
+    const initialSort = groupAndSortByProperty<FullAlbumDetails>(args, "artist_name", "release_year");
+    const removeArticles = (name: string) => name.replace(/^(The|A|An)\s+/i, '').trim();
+    return initialSort.sort((ag1,  ag2) => {
+        let artistA = removeArticles(ag1[0].artist_name);
+        let artistB = removeArticles(ag2[0].artist_name);
+        return artistA.localeCompare(artistB);
+    }).flat()
 }
 
 function filterPreorders(args: FullAlbumDetails[]) {
-    return args
-      .filter((arg) => isPreorder(arg) && !isAcquired(arg))
-      .sort((a, b) => sortByTime(new Date(b.acquired_date), new Date(a.acquired_date)))
+    const relevant = args.filter((arg) =>
+      (isPreorder(arg) && !isAcquired(arg)) || (!isPreorder(arg) && !isAcquired(arg)
+    ))
+    return relevant.sort((a, b) => sortByTime(new Date(b.acquired_date), new Date(a.acquired_date)))
 }
 
-export function sortLegacyEntries(args: FullAlbumDetails[], sort: SortType) {
+export function sortLegacyEntries(args: FullAlbumDetails[], sort: SortType['slug']) {
     switch (sort) {
         case "newest":
             return sortRecentlyAdded(args)
-        case "artist(a-z)":
+        case "artist-alphabetical":
             return sortArtists(args)
-        case "preorders":
+        case "orders-preorders":
             return filterPreorders(args)
         default:
             // runtime invalid 'sort' type failure

--- a/data/types.ts
+++ b/data/types.ts
@@ -6,9 +6,10 @@ interface SupabaseDbEntry {
 export interface Album extends SupabaseDbEntry {
   title: string;
   artist_id: number;
-  variant: string;
   purchase_date: string;
   acquired_date: string;
+  release_year: number;
+  variant: string;
   preordered: boolean;
   artwork_url: string;
 }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
     "eslint": "^8",
     "eslint-config-next": "14.2.4",
     "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-react": "^7.35.0",
+    "eslint-plugin-react-hooks": "^4.6.2",
     "postcss": "^8",
     "prettier-plugin-tailwindcss": "^0.6.5",
     "tailwindcss": "^3.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1092,7 +1092,7 @@ eslint-plugin-jsx-a11y@^6.7.1:
     safe-regex-test "^1.0.3"
     string.prototype.includes "^2.0.0"
 
-"eslint-plugin-react-hooks@^4.5.0 || 5.0.0-canary-7118f5dd7-20230705":
+"eslint-plugin-react-hooks@^4.5.0 || 5.0.0-canary-7118f5dd7-20230705", eslint-plugin-react-hooks@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.2.tgz#c829eb06c0e6f484b3fbb85a97e57784f328c596"
   integrity sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==
@@ -1120,6 +1120,30 @@ eslint-plugin-react@^7.33.2:
     resolve "^2.0.0-next.5"
     semver "^6.3.1"
     string.prototype.matchall "^4.0.11"
+
+eslint-plugin-react@^7.35.0:
+  version "7.35.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.35.0.tgz#00b1e4559896710e58af6358898f2ff917ea4c41"
+  integrity sha512-v501SSMOWv8gerHkk+IIQBkcGRGrO2nfybfj5pLxuJNFTPxxA3PSryhXTK+9pNbtkggheDdsC0E9Q8CuPk6JKA==
+  dependencies:
+    array-includes "^3.1.8"
+    array.prototype.findlast "^1.2.5"
+    array.prototype.flatmap "^1.3.2"
+    array.prototype.tosorted "^1.1.4"
+    doctrine "^2.1.0"
+    es-iterator-helpers "^1.0.19"
+    estraverse "^5.3.0"
+    hasown "^2.0.2"
+    jsx-ast-utils "^2.4.1 || ^3.0.0"
+    minimatch "^3.1.2"
+    object.entries "^1.1.8"
+    object.fromentries "^2.0.8"
+    object.values "^1.2.0"
+    prop-types "^15.8.1"
+    resolve "^2.0.0-next.5"
+    semver "^6.3.1"
+    string.prototype.matchall "^4.0.11"
+    string.prototype.repeat "^1.0.0"
 
 eslint-scope@^7.2.2:
   version "7.2.2"
@@ -2512,6 +2536,14 @@ string.prototype.matchall@^4.0.11:
     regexp.prototype.flags "^1.5.2"
     set-function-name "^2.0.2"
     side-channel "^1.0.6"
+
+string.prototype.repeat@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/string.prototype.repeat/-/string.prototype.repeat-1.0.0.tgz#e90872ee0308b29435aa26275f6e1b762daee01a"
+  integrity sha512-0u/TldDbKD8bFCQ/4f5+mNRrXwZ8hg2w7ZR8wa16e8z9XpePWl3eGEcUD0OXpEH/VJH/2G3gjUtR3ZOiBe2S/w==
+  dependencies:
+    define-properties "^1.1.3"
+    es-abstract "^1.17.5"
 
 string.prototype.trim@^1.2.9:
   version "1.2.9"


### PR DESCRIPTION
# Changelog

- navigation now allows for distinct labels and slugs
- preorders list is now orders and preorders
- artists now sorted alphabetically sans articles (a, an, the) and artist groups are sorted by album release years

# Other

- eslint added